### PR TITLE
Handling discrepancies caused by `BigInt.isValidInt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+.idea

--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ void printObj(String key, Object? val) =>
 Below is an example of how the decoder method works:
 
 ```dart
-  print
-("Decoding:
-"
-);print("------------------------");
+print("Decoding:");
+print("------------------------");
 var jsonMap = decodeJson(json) as Map<String, Object?>;
 printObj("sometext", jsonMap["sometext"]);
 printObj("bignumber", jsonMap["bignumber"]);
@@ -37,7 +35,6 @@ printObj("expnumber", jsonMap["expnumber"]);
 print("\nDecoding w/ settings:");
 print("------------------------");
 var decSettings = DecoderSettings(
-useIntWhenPossible: true,
 treatExpAsIntWhenPossible: true,
 );
 var jsonMap2 = decodeJson(
@@ -63,20 +60,17 @@ expnumber is of type double and has value: 2000.0.
 If you want to change how certain numbers are cast to integers, pass a `DecoderSettings` object. It has the following
 parameters:
 
-- `useIntWhenPossible`: By default, the decoder decodes any integer as a `BigInt`, if instead you want the decoder to
-  return an `int` where possible (i.e. the value can fit in an int), then set this to true.
+- `whetherUseInt`: controls whether to use `int` rather than `BigInt` when possible.
+  - By default, it uses `BigInt.isValidInt` to judge whether to use `int` or `BigInt`.
+  - If you want to interpret **all** numbers as `BigInt`, use something like`(_) => false` 
+  - If your project targets both native and web, it is recommended that you control it yourself (for example, use `(v) => v <= BigInt.parse('9007199254740991')`)
 - `treatExpAsIntWhenPossible`: By default, the decoder treats values written in exponential notation (e.g. 1e12) as
   doubles. To treat these as integers when possible (i.e. if they evaluate to an integer), set this to true.
 
 ```dart
-  print
-("\nDecoding w/ settings:
-"
-);print("------------------------");
-var decSettings = DecoderSettings(
-useIntWhenPossible: true,
-treatExpAsIntWhenPossible: true,
-);
+print("\nDecoding w/ settings:");
+print("------------------------");
+var decSettings = DecoderSettings(treatExpAsIntWhenPossible: true);
 var jsonMap2 = decodeJson(
 json,
 settings: decSettings,
@@ -99,17 +93,10 @@ expnumber is of type int and has value: 2000.
 Below is an example of how the encoder method works:
 
 ```dart
-  print
-("\nEncoding:
-"
-);print("------------------------");
-String jsonNew = encodeJson(
-jsonMap
-);
-print
-(
-jsonNew
-);
+print("\nEncoding:");
+print("------------------------");
+String jsonNew = encodeJson(jsonMap);
+print(jsonNew);
 ```
 
 It prints out:
@@ -131,20 +118,15 @@ If you want to format the encoded JSON, use the `EncoderSettings` object. It has
 - `afterKeyIndent`: how much to indent between the key and value in a map. The default is the empty String.
 
 ```dart
-  print
-("\nEncoding w/ Settings:
-"
-);print("------------------------");
+print("\nEncoding w/ Settings:");
+print("------------------------");
 final encSettings = EncoderSettings(
 indent: "  ",
 singleLineLimit: 30,
 afterKeyIndent: " ",
 );
 String jsonFormatted = encodeJson(jsonMap2, settings: encSettings);
-print
-(
-jsonFormatted
-);
+print(jsonFormatted);
 ```
 
 It prints out:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,37 @@
-# json_bigint
-This is a dart package that provides methods for encoding and decoding JSON strings from/to dart maps, with out-of-the-box support for [BigInt](https://api.flutter.dev/flutter/dart-core/BigInt-class.html).
+> This is a fork of the `json_bigint` library
 
+## What does this fork do?
+
+- Remove unnecessary dependencies `collect` (this also reduces function call costs)
+- Add a class called `JSONBigIntConfig` for global configuration of encoding and decoding settings
+- Change `useIntWhenPossible` of `DecoderSettings` class to `whetherUseInt` to provide more fine-grained control (This is mainly to avoid errors caused by the difference between `BigInt.isValidInt` on native and web)
+
+### Example of `whetherUseInt`
+
+```dart
+void main() {
+  // control whether to use int
+  final result = decodeJson(
+    '{"a": 1, "b": [2, 3.4], "c": false, "d": 123}',
+    // use int only when value is less than 10, otherwise use BigInt
+    settings: DecoderSettings(whetherUseInt: (v) => v < BigInt.from(10)),
+  ) as Map;
+  print(result['a'].runtimeType); // int
+  print(result['d'].runtimeType); // _BigIntImpl
+}
+```
+
+---
+
+# json_bigint
+
+This is a dart package that provides methods for encoding and decoding JSON strings from/to dart maps, with
+out-of-the-box support for [BigInt](https://api.flutter.dev/flutter/dart-core/BigInt-class.html).
 
 ## Usage
+
 The examples will make use of the following common code:
+
 ```dart
 import 'package:json_bigint/json_bigint.dart';
 
@@ -18,31 +46,35 @@ void printObj(String key, Object? val) =>
 ```
 
 ### Decoding
+
 Below is an example of how the decoder method works:
 
 ```dart
-  print("Decoding:");
-  print("------------------------");
-  var jsonMap = decodeJson(json) as Map<String, Object?>;
-  printObj("sometext", jsonMap["sometext"]);
-  printObj("bignumber", jsonMap["bignumber"]);
-  printObj("expnumber", jsonMap["expnumber"]);
+  print
+("Decoding:
+"
+);print("------------------------");
+var jsonMap = decodeJson(json) as Map<String, Object?>;
+printObj("sometext", jsonMap["sometext"]);
+printObj("bignumber", jsonMap["bignumber"]);
+printObj("expnumber", jsonMap["expnumber"]);
 
-  print("\nDecoding w/ settings:");
-  print("------------------------");
-  var decSettings = DecoderSettings(
-    useIntWhenPossible: true,
-    treatExpAsIntWhenPossible: true,
-  );
-  var jsonMap2 = decodeJson(
-    json,
-    settings: decSettings,
-  ) as Map<String, Object?>;
-  printObj("bignumber", jsonMap2["bignumber"]);
-  printObj("expnumber", jsonMap2["expnumber"]);
+print("\nDecoding w/ settings:");
+print("------------------------");
+var decSettings = DecoderSettings(
+useIntWhenPossible: true,
+treatExpAsIntWhenPossible: true,
+);
+var jsonMap2 = decodeJson(
+json,
+settings: decSettings,
+) as Map<String, Object?>;
+printObj("bignumber", jsonMap2["bignumber"]);
+printObj("expnumber", jsonMap2["expnumber"]);
 ```
 
 It prints out:
+
 ```
 Decoding:
 ------------------------
@@ -52,26 +84,34 @@ expnumber is of type double and has value: 2000.0.
 ```
 
 ### Decoding Settings
-If you want to change how certain numbers are cast to integers, pass a `DecoderSettings` object. It has the following parameters:
-- `useIntWhenPossible`: By default, the decoder decodes any integer as a `BigInt`, if instead you want the decoder to return an `int` where possible (i.e. the value can fit in an int), then set this to true. 
-- `treatExpAsIntWhenPossible`: By default, the decoder treats values written in exponential notation (e.g. 1e12) as doubles. To treat these as integers when possible (i.e. if they evaluate to an integer), set this to true.
+
+If you want to change how certain numbers are cast to integers, pass a `DecoderSettings` object. It has the following
+parameters:
+
+- `useIntWhenPossible`: By default, the decoder decodes any integer as a `BigInt`, if instead you want the decoder to
+  return an `int` where possible (i.e. the value can fit in an int), then set this to true.
+- `treatExpAsIntWhenPossible`: By default, the decoder treats values written in exponential notation (e.g. 1e12) as
+  doubles. To treat these as integers when possible (i.e. if they evaluate to an integer), set this to true.
 
 ```dart
-  print("\nDecoding w/ settings:");
-  print("------------------------");
-  var decSettings = DecoderSettings(
-    useIntWhenPossible: true,
-    treatExpAsIntWhenPossible: true,
-  );
-  var jsonMap2 = decodeJson(
-    json,
-    settings: decSettings,
-  ) as Map<String, Object?>;
-  printObj("bignumber", jsonMap2["bignumber"]);
-  printObj("expnumber", jsonMap2["expnumber"]);
+  print
+("\nDecoding w/ settings:
+"
+);print("------------------------");
+var decSettings = DecoderSettings(
+useIntWhenPossible: true,
+treatExpAsIntWhenPossible: true,
+);
+var jsonMap2 = decodeJson(
+json,
+settings: decSettings,
+) as Map<String, Object?>;
+printObj("bignumber", jsonMap2["bignumber"]);
+printObj("expnumber", jsonMap2["expnumber"]);
 ```
 
 It prints out:
+
 ```
 Decoding w/ settings:
 ------------------------
@@ -80,16 +120,25 @@ expnumber is of type int and has value: 2000.
 ```
 
 ### Encoding
+
 Below is an example of how the encoder method works:
 
 ```dart
-  print("\nEncoding:");
-  print("------------------------");
-  String jsonNew = encodeJson(jsonMap);
-  print(jsonNew);
+  print
+("\nEncoding:
+"
+);print("------------------------");
+String jsonNew = encodeJson(
+jsonMap
+);
+print
+(
+jsonNew
+);
 ```
 
 It prints out:
+
 ```
 Encoding:
 ------------------------
@@ -97,24 +146,34 @@ Encoding:
 ```
 
 ### Encoder Settings
+
 If you want to format the encoded JSON, use the `EncoderSettings` object. It has the following parameters:
-- `indent`: how much to indent at each level of the JSON. Should usually be some number of consecutive <kbd>Space</kbd> or <kbd>Tab</kbd> characters. If the default (i.e. empty String) is used, no new lines will be added in the JSON.
-- `singleLineLimit`: how long a map/list can be before its elements are indented. If the default (i.e. `null`) is used, all elements will always be indented.
+
+- `indent`: how much to indent at each level of the JSON. Should usually be some number of consecutive <kbd>Space</kbd>
+  or <kbd>Tab</kbd> characters. If the default (i.e. empty String) is used, no new lines will be added in the JSON.
+- `singleLineLimit`: how long a map/list can be before its elements are indented. If the default (i.e. `null`) is used,
+  all elements will always be indented.
 - `afterKeyIndent`: how much to indent between the key and value in a map. The default is the empty String.
 
 ```dart
-  print("\nEncoding w/ Settings:");
-  print("------------------------");
-  final encSettings = EncoderSettings(
-    indent: "  ",
-    singleLineLimit: 30,
-    afterKeyIndent: " ",
-  );
-  String jsonFormatted = encodeJson(jsonMap2, settings: encSettings);
-  print(jsonFormatted);
+  print
+("\nEncoding w/ Settings:
+"
+);print("------------------------");
+final encSettings = EncoderSettings(
+indent: "  ",
+singleLineLimit: 30,
+afterKeyIndent: " ",
+);
+String jsonFormatted = encodeJson(jsonMap2, settings: encSettings);
+print
+(
+jsonFormatted
+);
 ```
 
 It prints out:
+
 ```
 Encoding w/ Settings:
 ------------------------
@@ -126,16 +185,29 @@ Encoding w/ Settings:
 ```
 
 ## Notes
+
 This package does not support [commented JSON](https://json5.org/), but neither does dart:convert...
 
 ## Rationale
-If you've ever used the JSON serializer provided by dart's standard library, [dart:convert](https://api.dart.dev/dart-convert/dart-convert-library.html), you might have noticed that it treats any integer that cannot fit in a 64 bit signed integer as a double. This is a consequence of the library being written back when dart only had one `num` type.
 
-This means that any integers in the JSON will irreversibly lose their precision should they not be too large (or small). And, unfortunately, there is currently no support to override the converter to make use the BigInt type in those cases. This makes the library unsuitable for applications in which large integers need to be (de)serialized exactly.
+If you've ever used the JSON serializer provided by dart's standard
+library, [dart:convert](https://api.dart.dev/dart-convert/dart-convert-library.html), you might have noticed that it
+treats any integer that cannot fit in a 64 bit signed integer as a double. This is a consequence of the library being
+written back when dart only had one `num` type.
+
+This means that any integers in the JSON will irreversibly lose their precision should they not be too large (or small).
+And, unfortunately, there is currently no support to override the converter to make use the BigInt type in those cases.
+This makes the library unsuitable for applications in which large integers need to be (de)serialized exactly.
 
 ### Why not use a third-party serializer?
-As it turns out, all the big JSON serialization packages (e.g. [json_serializable](https://pub.dev/packages/json_serializable), [dart_mappable](https://pub.dev/packages/dart_mappable), [build-value](https://pub.dev/packages/built_value), [JSON5](https://pub.dev/packages/json5), etc.) use the dart:convert serializer under the hood. Meaning there is no way for those packages to override this behavior either.
+
+As it turns out, all the big JSON serialization packages (
+e.g. [json_serializable](https://pub.dev/packages/json_serializable), [dart_mappable](https://pub.dev/packages/dart_mappable), [build-value](https://pub.dev/packages/built_value), [JSON5](https://pub.dev/packages/json5),
+etc.) use the dart:convert serializer under the hood. Meaning there is no way for those packages to override this
+behavior either.
 
 This is why I simply bit the bullet and made one myself. One that doesn't depend on dart:convert at all.
 
-*Encoding* JSON is relatively simple (although formatting/pretty print adds a bit of complexity) but *decoding* is another matter. Indeed, if it wasn't for the wonderful [petitparser](https://pub.dev/packages/petitparser) package, it would have been much more difficult.
+*Encoding* JSON is relatively simple (although formatting/pretty print adds a bit of complexity) but *decoding* is
+another matter. Indeed, if it wasn't for the wonderful [petitparser](https://pub.dev/packages/petitparser) package, it
+would have been much more difficult.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,3 @@
-> This is a fork of the `json_bigint` library
-
-## What does this fork do?
-
-- Remove unnecessary dependencies `collect` (this also reduces function call costs)
-- Add a class called `JSONBigIntConfig` for global configuration of encoding and decoding settings
-- Change `useIntWhenPossible` of `DecoderSettings` class to `whetherUseInt` to provide more fine-grained control (This is mainly to avoid errors caused by the difference between `BigInt.isValidInt` on native and web)
-
-### Example of `whetherUseInt`
-
-```dart
-void main() {
-  // control whether to use int
-  final result = decodeJson(
-    '{"a": 1, "b": [2, 3.4], "c": false, "d": 123}',
-    // use int only when value is less than 10, otherwise use BigInt
-    settings: DecoderSettings(whetherUseInt: (v) => v < BigInt.from(10)),
-  ) as Map;
-  print(result['a'].runtimeType); // int
-  print(result['d'].runtimeType); // _BigIntImpl
-}
-```
-
----
-
 # json_bigint
 
 This is a dart package that provides methods for encoding and decoding JSON strings from/to dart maps, with

--- a/example/main.dart
+++ b/example/main.dart
@@ -20,7 +20,6 @@ void main() {
   print("\nDecoding w/ settings:");
   print("------------------------");
   final decSettings = DecoderSettings(
-    useIntWhenPossible: true,
     treatExpAsIntWhenPossible: true,
   );
   final jsonMap2 = decodeJson(
@@ -44,4 +43,13 @@ void main() {
   );
   String jsonFormatted = encodeJson(jsonMap2, settings: encSettings);
   print(jsonFormatted);
+
+  // control whether to use int
+  final result = decodeJson(
+    '{"a": 1, "b": [2, 3.4], "c": false, "d": 123}',
+    // use int only when value is less than 10, otherwise use BigInt
+    settings: DecoderSettings(whetherUseInt: (v) => v < BigInt.from(10)),
+  ) as Map;
+  print(result['a'].runtimeType); // int
+  print(result['d'].runtimeType); // _BigIntImpl
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -45,11 +45,26 @@ void main() {
   print(jsonFormatted);
 
   // control whether to use int
-  final result = decodeJson(
-    '{"a": 1, "b": [2, 3.4], "c": false, "d": 123}',
+  String json2 = '''{
+    "numberOutOfIntRange": 99999999999999999999999,
+    "numberInIntRange": 123456,
+    "aSmallNumber": 42
+  }''';
+  final resultWithDefaultSetting = decodeJson(json2) as Map;
+  printObj('numberOutOfIntRange',
+      resultWithDefaultSetting['numberOutOfIntRange']); // _BigIntImpl
+  printObj(
+      'numberInIntRange', resultWithDefaultSetting['numberInIntRange']); // int
+  printObj('aSmallNumber', resultWithDefaultSetting['aSmallNumber']); // int
+
+  final resultWithCustomSetting = decodeJson(
+    json2,
     // use int only when value is less than 10, otherwise use BigInt
     settings: DecoderSettings(whetherUseInt: (v) => v < BigInt.from(10)),
   ) as Map;
-  print(result['a'].runtimeType); // int
-  print(result['d'].runtimeType); // _BigIntImpl
+  printObj('numberOutOfIntRange',
+      resultWithCustomSetting['numberOutOfIntRange']); // _BigIntImpl
+  printObj('numberInIntRange',
+      resultWithCustomSetting['numberInIntRange']); // _BigIntImpl
+  printObj('aSmallNumber', resultWithDefaultSetting['aSmallNumber']); // int
 }

--- a/lib/json_bigint.dart
+++ b/lib/json_bigint.dart
@@ -2,5 +2,5 @@
 /// [encodeJson] methods that natively support [BigInt].
 library json_bigint;
 
-export 'src/decoder.dart' show decodeJson, DecoderSettings;
+export 'src/decoder.dart' show decodeJson, DecoderSettings, JSONBigIntConfig;
 export 'src/encoder.dart' show encodeJson, EncoderSettings;

--- a/lib/src/decoder.dart
+++ b/lib/src/decoder.dart
@@ -11,6 +11,9 @@ bool useIntWhenValid(BigInt bi) => bi.isValidInt;
 
 @immutable
 class DecoderSettings {
+  /// controls whether to use [int] rather than [BigInt] when possible.
+  ///
+  /// Default to [useIntWhenValid], which uses [BigInt.isValidInt] to determine whether to use [int].
   final bool Function(BigInt bi) whetherUseInt;
 
   /// Whether to treat exponentials (e.g. 12e+20) as integers when possible.

--- a/lib/src/encoder.dart
+++ b/lib/src/encoder.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import 'constants.dart';
+import 'decoder.dart';
 
 @immutable
 class EncoderSettings {
@@ -22,8 +23,11 @@ class EncoderSettings {
 String encodeJson(
   Object? val, {
   int level = 1,
-  EncoderSettings settings = const EncoderSettings(),
+  EncoderSettings? settings,
 }) {
+  // since JSONBigIntConfig.encoderSettings is not const, we can't use it as default value
+  settings ??= JSONBigIntConfig.encoderSettings;
+
   if (val is Map) {
     return encodeMap(val, level: level, settings: settings);
   }

--- a/lib/src/encoder.dart
+++ b/lib/src/encoder.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
 import 'constants.dart';
@@ -84,10 +83,10 @@ String _encodeComposite(List<String> valsEnc, String dL, String dR, int level,
       (settings.singleLineLimit == null || //has no single line limit
           totalChars > settings.singleLineLimit!); //limit isnt't exceeded
 
-  valsEnc.forEachIndexed((i, str) {
+  for (int index = 0; index < valsEnc.length; index += 1) {
     if (doIndent) finalStr += "\n${settings.indent * level}";
-    finalStr += str;
-    if (i != valsEnc.length - 1) {
+    finalStr += valsEnc[index];
+    if (index != valsEnc.length - 1) {
       //not last item
       finalStr += ",";
     } else if (doIndent) {
@@ -97,6 +96,6 @@ String _encodeComposite(List<String> valsEnc, String dL, String dR, int level,
       //last item w/o indent
       finalStr += dR;
     }
-  });
+  }
   return finalStr;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_bigint
 description: A json serializer for dart that supports BigInt.
-version: 2.0.0
+version: 3.0.0
 repository: https://github.com/ozaner/json_bigint
 issue_tracker: https://github.com/ozaner/json_bigint/issues
 homepage: https://github.com/ozaner/json_bigint

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 
 dependencies:
   meta: ^1.8.0
-  collection: ^1.16.0
   petitparser: ^5.1.0
 
 dev_dependencies:


### PR DESCRIPTION
## Motivation for proposing this PR

I used this library when compiling my project for web, but I found that the internal processing was a bit different for web and native (caused by `BigInt.isValidInt`). In addition, passing a custom configuration in each call to `decodeJson` was a bit repetitive, so I wanted to define a global class to configure it.

[Numbers in Dart
](https://dart.dev/guides/language/numbers#differences-in-behavior)

## What did this pr do?

- Remove unnecessary dependencies `collect` (this also reduces function call costs)
- Add a class called `JSONBigIntConfig` for global configuration of encoding and decoding settings
- Change `useIntWhenPossible` of `DecoderSettings` class to `whetherUseInt` to provide more fine-grained control (This is mainly to avoid errors caused by the difference between `BigInt.isValidInt` on native and web)